### PR TITLE
Fix blocking assignments in dual-port RAM sequential logic

### DIFF
--- a/src/dcache/dcache_core_tag_ram.v
+++ b/src/dcache/dcache_core_tag_ram.v
@@ -54,9 +54,9 @@ reg [20:0] ram_read0_q;
 always @ (posedge clk1_i)
 begin
     if (wr1_i)
-        ram[addr1_i] = data1_i;
+        ram[addr1_i] <= data1_i;
 
-    ram_read0_q = ram[addr0_i];
+    ram_read0_q <= ram[addr0_i];
 end
 
 assign data0_o = ram_read0_q;


### PR DESCRIPTION
### Description

This PR corrects Verilog coding style in the `dcache_core_tag_ram` module by replacing blocking assignments (`=`) with non-blocking assignments (`<=`) in the clocked process. This change ensures proper synchronous design practices are followed for the dual-port tag RAM implementation.

### Changes Made

- Updated assignments in `always @(posedge clk1_i)` block to use non-blocking semantics
- Maintained identical functionality for both read and write ports
- Preserved all existing module interfaces and behavior

### Impact

- Zero functional change to the module's operation
- Improved simulation accuracy for concurrent read/write cases
- Better alignment with industry best practices for synchronous design
